### PR TITLE
Limit external pipeline to run only in certain environments.

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -41,6 +41,13 @@ configure :build do
     html.remove_intertag_spaces = true
   end
 
+  # Initialise Gulp Starter when running `middleman build`
+  activate :external_pipeline,
+    name: :gulp,
+    command: "npm run production",
+    source: ".tmp",
+    latency: 1
+
   # Ignore the CSS file Middleman normally generates
   # Middleman expects `site.css.scss` → `site.css`
   # We strip the `.css` to prevent Gulp generating `site.css.css`
@@ -63,10 +70,3 @@ configure :build do
     ignore 'static/*'
   end
 end
-
-# Initialise Gulp Starter when running `middleman build` and `middleman serve`
-activate :external_pipeline,
-  name: :gulp,
-  command: build? ? 'npm run production' : 'npm run gulp',
-  source: ".tmp",
-  latency: 1

--- a/environments/gulp.rb
+++ b/environments/gulp.rb
@@ -1,0 +1,7 @@
+# Invoke this environment by appending `-e gulp` from the command line.
+# Example: `middleman server -e gulp`
+activate :external_pipeline,
+  name: :gulp,
+  command: "npm run gulp",
+  source: ".tmp",
+  latency: 1


### PR DESCRIPTION
Not sure if this is something you want to go with or not, but I've found it very helpful to have control over when the external pipeline runs. With this change, it still runs by default on `middleman build`, and when running `middleman server`, it can be invoked by appending `-e gulp`. 

The default implementation (wherein the external_pipeline always runs) can be problematic when running other app-invoking operations, such as `middleman console`.

---
- Add environments directory.
- Introduce "gulp" environment.
- Activate external_pipeline only in build block (config.rb) or in environments/gulp.rb

Reference:
- https://middlemanapp.com/basics/upgrade-v4/#environments-and-changes-to-configure-blocks
- https://github.com/middleman/middleman/tree/master/middleman-core/fixtures/env-app
