### PR TITLE
Fix issue with Gulp clean task breaking directory watch on Linux

### DIFF
--- a/gulpfile.js/tasks/clean.js
+++ b/gulpfile.js/tasks/clean.js
@@ -3,7 +3,10 @@ var del    = require('del')
 var config = require('../config')
 
 var cleanTask = function (cb) {
-  del([config.root.dest]).then(function (paths) {
+  // Delete everything in the dest directory, but not the directory itself or
+  // else inotify on Linux may stop tracking changes. The glob pattern **
+  // matches all children and the parent.
+  del([config.root.dest + '/**', '!' + config.root.dest]).then(function (paths) {
     cb()
   })
 }


### PR DESCRIPTION
Excellent work on this starter project, it has been incredibly useful! I just ran into one problem (stylesheets not loading using `middleman server`) and after quite a bit of debugging I found that the Linux kernel’s inotify events were firing initially when the css file was deleted, but then stopped working. First I thought it was a race condition, but ultimately I realized the issue was that the .tmp directory itself was being deleted with the Gulp clean process and then any changes within the .tmp folder after that weren’t being picked up. Here's a PR to fix this. There may be cleaner approach (I'm open to suggestions) but I've verified that this fixes the problem on Ubuntu 14.04, and still works on OS X too.